### PR TITLE
Major refactoring to separate Svelte components

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 	"type": "module",
 	"packageManager": "pnpm@9.1.4",
 	"dependencies": {
-		"@picocss/pico": "^2.0.3",
+		"@picocss/pico": "^2.0.6",
 		"svelte-i18n": "^4.0.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@picocss/pico':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.6
+        version: 2.0.6
       svelte-i18n:
         specifier: ^4.0.0
         version: 4.0.0(svelte@4.2.19)
@@ -229,8 +229,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@picocss/pico@2.0.3':
-    resolution: {integrity: sha512-uIWvDcZnbA+oo4mpz8LeA05huCWbDnUz8Ad2NZXTFn6SrEXBtIdKDu+/bOD4oI8hJHp6dUEEvDLim2+qqSgruQ==}
+  '@picocss/pico@2.0.6':
+    resolution: {integrity: sha512-/d8qsykowelD6g8k8JYgmCagOIulCPHMEc2NC4u7OjmpQLmtSetLhEbt0j1n3fPNJVcrT84dRp0RfJBn3wJROA==}
     engines: {node: '>=18.19.0'}
 
   '@polka/url@1.0.0-next.24':
@@ -952,7 +952,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  '@picocss/pico@2.0.3': {}
+  '@picocss/pico@2.0.6': {}
 
   '@polka/url@1.0.0-next.24': {}
 

--- a/src/lib/components/Game.svelte
+++ b/src/lib/components/Game.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { t } from 'svelte-i18n';
+	import { cardsInGame } from '$lib/constants/cardsInGame';
+	import { game } from '$lib/managers/game';
+	import type { GameState } from '../interfaces/gameState';
+	import { gameStore } from '../stores/gameStore';
+
+	let gameState: GameState;
+	gameStore.subscribe((value) => (gameState = value));
+</script>
+
+<h1 class="target">
+	{gameState.players[gameState.currentPlayerIndex].name}
+</h1>
+
+<article>
+	<h2>{gameState.cards[gameState.currentCardIndex].title}</h2>
+	<p>
+		{gameState.cards[gameState.currentCardIndex].description}
+	</p>
+	{#if gameState.cards[gameState.currentCardIndex].targetPlayer}
+		<b>{$t('target')}: {game.getTarget(gameState)}</b>
+	{/if}
+</article>
+
+{#each gameState.events as event}
+	{#if event.ended === true}
+		<h1 class="event-text">{event.person}, {$t('can-stop-the-mission')} {event.title}</h1>
+	{/if}
+{/each}
+
+{#if gameState.currentCardIndex + 1 < 29}
+	<button on:click={gameStore.showNextCard}>{$t('next-card')}</button>
+{:else if gameState.currentCardIndex + 1 === 29}
+	<button on:click={gameStore.showNextCard}>{$t('last-card')}</button>
+{:else if gameState.currentCardIndex + 1 === 30}
+	<button class="pico-background-red-500" on:click={gameStore.showNextCard}
+		>{$t('game-over')}</button
+	>
+{/if}
+
+<p class="game-status">{gameState.currentCardIndex + 1}/{cardsInGame}</p>
+
+<style>
+	article {
+		width: 50%;
+		max-width: 600px;
+	}
+	.game-status {
+		margin-top: 1rem;
+	}
+</style>

--- a/src/lib/components/Game.svelte
+++ b/src/lib/components/Game.svelte
@@ -2,8 +2,8 @@
 	import { t } from 'svelte-i18n';
 	import { cardsInGame } from '$lib/constants/cardsInGame';
 	import { game } from '$lib/managers/game';
-	import type { GameState } from '../interfaces/gameState';
-	import { gameStore } from '../stores/gameStore';
+	import type { GameState } from '$lib/interfaces/gameState';
+	import { gameStore } from '$lib/stores/gameStore';
 
 	let gameState: GameState;
 	gameStore.subscribe((value) => (gameState = value));

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { Language } from '../languages/language';
+	import { gameStore } from '../stores/gameStore';
+	import { languageStore } from '../stores/languageStore';
+
+	async function changeLanguage(event: Event) {
+		const select = event.target as HTMLSelectElement;
+		const newLanguage = select.value as Language;
+		await languageStore.changeLanguage(newLanguage);
+		await gameStore.updateCards();
+	}
+</script>
+
+<select class="language pico-background-azure-500" on:change={changeLanguage}>
+	{#each Object.values(Language) as language}
+		<option value={language}>{language}</option>
+	{/each}
+</select>
+
+<button class="reset pico-background-azure-500" on:click={gameStore.reset}> &#x21bb; </button>
+
+<style>
+	.reset,
+	.language {
+		position: absolute;
+		top: 1rem;
+		width: 2.5rem;
+		height: 2.5rem;
+		padding: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		text-align: center;
+		border-radius: 50%;
+	}
+
+	.reset {
+		right: 1rem;
+		font-size: 1.3rem;
+	}
+
+	.language {
+		left: 1rem;
+		font-weight: bold;
+		background-image: none !important;
+	}
+</style>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { Language } from '../languages/language';
-	import { gameStore } from '../stores/gameStore';
-	import { languageStore } from '../stores/languageStore';
+	import { Language } from '$lib/languages/language';
+	import { gameStore } from '$lib/stores/gameStore';
+	import { languageStore } from '$lib/stores/languageStore';
 
 	async function changeLanguage(event: Event) {
 		const select = event.target as HTMLSelectElement;

--- a/src/lib/components/Landing.svelte
+++ b/src/lib/components/Landing.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { t } from 'svelte-i18n';
+	import { ApplicationState } from '$lib/constants/applicationState';
+	import { gameStore } from '../stores/gameStore';
+</script>
+
+<h1>{$t('title')}</h1>
+<button 
+    on:click={() => gameStore.changeGameState(ApplicationState.ADDING_PLAYERS)}
+>
+    {$t('main-menu-start-button')}
+</button>
+

--- a/src/lib/components/Lobby.svelte
+++ b/src/lib/components/Lobby.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { t } from 'svelte-i18n';
-	import { gameStore } from '../stores/gameStore';
-	import type { GameState } from '../interfaces/gameState';
+	import { gameStore } from '$lib/stores/gameStore';
+	import type { GameState } from '$lib/interfaces/gameState';
 
 	let gameState: GameState;
 	gameStore.subscribe((value) => (gameState = value));

--- a/src/lib/components/Lobby.svelte
+++ b/src/lib/components/Lobby.svelte
@@ -1,81 +1,78 @@
 <script lang="ts">
-    import { t } from 'svelte-i18n';
-    import { gameStore } from '../stores/gameStore';
-    import type { GameState } from '../interfaces/gameState';
-    
-    let gameState: GameState;
-    gameStore.subscribe(value => gameState = value);
+	import { t } from 'svelte-i18n';
+	import { gameStore } from '../stores/gameStore';
+	import type { GameState } from '../interfaces/gameState';
 
-    function handleKeyPress(event: KeyboardEvent) {
-        if (event.key === 'Enter' && gameState.playerName) {
-            gameStore.addPlayer(gameState.playerName);
-            gameState.playerName = '';
-        }
-    }
+	let gameState: GameState;
+	gameStore.subscribe((value) => (gameState = value));
+
+	function handleKeyPress(event: KeyboardEvent) {
+		if (event.key === 'Enter' && gameState.playerName) {
+			gameStore.addPlayer(gameState.playerName);
+			gameState.playerName = '';
+		}
+	}
 </script>
 
 <h2>{$t('add-player-names')}</h2>
 <input
-    type="text"
-    bind:value={gameState.playerName}
-    placeholder={$t('add-player-name')}
-    on:keypress={handleKeyPress}
-    class="input"
+	type="text"
+	bind:value={gameState.playerName}
+	placeholder={$t('add-player-name')}
+	on:keypress={handleKeyPress}
+	class="input"
 />
 {#if gameState.players.length > 0}
-    <ul class="player-list">
-        {#each gameState.players as player (player.id)}
-            <li>
-                <button 
-                    class="remove-player" 
-                    on:click={() => gameStore.removePlayer(player.id)}
-                >
-                    &#x2716;
-                </button>
-                {player.name}
-            </li>
-        {/each}
-    </ul>
+	<ul class="player-list">
+		{#each gameState.players as player (player.id)}
+			<li>
+				<button class="remove-player" on:click={() => gameStore.removePlayer(player.id)}>
+					&#x2716;
+				</button>
+				{player.name}
+			</li>
+		{/each}
+	</ul>
 {/if}
-<button 
-    class="pico-background-jade-500" 
-    disabled={gameState.players.length < 2} 
-    on:click={() => gameStore.startGame()}
+<button
+	class="pico-background-jade-500"
+	disabled={gameState.players.length < 2}
+	on:click={() => gameStore.startGame()}
 >
-    {$t('game-start-button')}
+	{$t('game-start-button')}
 </button>
 
 <style>
-    .player-list {
-        padding-left: 0;
-    }
+	.player-list {
+		padding-left: 0;
+	}
 
-    .player-list li {
-        list-style-type: none;
-    }
+	.player-list li {
+		list-style-type: none;
+	}
 
-    .remove-player {
-        all: unset;
-        background-color: transparent;
-        cursor: pointer;
-        font-size: 14px;
-        color: #666;
-        transition: color 0.2s ease;
-    }
+	.remove-player {
+		all: unset;
+		background-color: transparent;
+		cursor: pointer;
+		font-size: 14px;
+		color: #666;
+		transition: color 0.2s ease;
+	}
 
-    .remove-player:hover {
-        color: #e74c3c;
-    }
+	.remove-player:hover {
+		color: #e74c3c;
+	}
 
-    input {
-        width: 50%;
-        max-width: 300px;
-        padding: 0.5rem 1rem;
-        border-radius: 0.5rem;
-        outline: none;
-    }
+	input {
+		width: 50%;
+		max-width: 300px;
+		padding: 0.5rem 1rem;
+		border-radius: 0.5rem;
+		outline: none;
+	}
 
-    input:focus {
-        border-color: #2980b9;
-    }
+	input:focus {
+		border-color: #2980b9;
+	}
 </style>

--- a/src/lib/components/Lobby.svelte
+++ b/src/lib/components/Lobby.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+    import { t } from 'svelte-i18n';
+    import { gameStore } from '../stores/gameStore';
+    import type { GameState } from '../interfaces/gameState';
+    
+    let gameState: GameState;
+    gameStore.subscribe(value => gameState = value);
+
+    function handleKeyPress(event: KeyboardEvent) {
+        if (event.key === 'Enter' && gameState.playerName) {
+            gameStore.addPlayer(gameState.playerName);
+            gameState.playerName = '';
+        }
+    }
+</script>
+
+<h2>{$t('add-player-names')}</h2>
+<input
+    type="text"
+    bind:value={gameState.playerName}
+    placeholder={$t('add-player-name')}
+    on:keypress={handleKeyPress}
+    class="input"
+/>
+{#if gameState.players.length > 0}
+    <ul class="player-list">
+        {#each gameState.players as player (player.id)}
+            <li>
+                <button 
+                    class="remove-player" 
+                    on:click={() => gameStore.removePlayer(player.id)}
+                >
+                    &#x2716;
+                </button>
+                {player.name}
+            </li>
+        {/each}
+    </ul>
+{/if}
+<button 
+    class="pico-background-jade-500" 
+    disabled={gameState.players.length < 2} 
+    on:click={() => gameStore.startGame()}
+>
+    {$t('game-start-button')}
+</button>
+
+<style>
+    .player-list {
+        padding-left: 0;
+    }
+
+    .player-list li {
+        list-style-type: none;
+    }
+
+    .remove-player {
+        all: unset;
+        background-color: transparent;
+        cursor: pointer;
+        font-size: 14px;
+        color: #666;
+        transition: color 0.2s ease;
+    }
+
+    .remove-player:hover {
+        color: #e74c3c;
+    }
+
+    input {
+        width: 50%;
+        max-width: 300px;
+        padding: 0.5rem 1rem;
+        border-radius: 0.5rem;
+        outline: none;
+    }
+
+    input:focus {
+        border-color: #2980b9;
+    }
+</style>

--- a/src/lib/components/Start.svelte
+++ b/src/lib/components/Start.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { t } from 'svelte-i18n';
 	import { ApplicationState } from '$lib/constants/applicationState';
-	import { gameStore } from '../stores/gameStore';
+	import { gameStore } from '$lib/stores/gameStore';
 </script>
 
 <h1>{$t('title')}</h1>

--- a/src/lib/components/Start.svelte
+++ b/src/lib/components/Start.svelte
@@ -5,9 +5,6 @@
 </script>
 
 <h1>{$t('title')}</h1>
-<button 
-    on:click={() => gameStore.changeGameState(ApplicationState.ADDING_PLAYERS)}
->
-    {$t('main-menu-start-button')}
+<button on:click={() => gameStore.changeGameState(ApplicationState.LOBBY)}>
+	{$t('main-menu-start-button')}
 </button>
-

--- a/src/lib/constants/applicationState.ts
+++ b/src/lib/constants/applicationState.ts
@@ -1,6 +1,6 @@
 export enum ApplicationState {
+	START = 'start',
 	LOBBY = 'lobby',
-	ADDING_PLAYERS = 'adding_players',
 	PLAYING = 'playing',
-	GAME_OVER = 'game_over'
+	ENDING = 'ending'
 }

--- a/src/lib/interfaces/gameState.ts
+++ b/src/lib/interfaces/gameState.ts
@@ -19,7 +19,7 @@ export function createNewGame(): GameState {
 		playerName: '',
 		currentCardIndex: 0,
 		currentPlayerIndex: 0,
-		state: ApplicationState.LOBBY,
+		state: ApplicationState.START,
 		players: [],
 		events: []
 	};

--- a/src/lib/managers/game.ts
+++ b/src/lib/managers/game.ts
@@ -1,8 +1,8 @@
-import { type GameState } from "$lib/interfaces/gameState";
-import { type Player } from "$lib/interfaces/player";
-import { type GameEvent } from "$lib/interfaces/gameEvent";
-import { cardsInGame } from "$lib/constants/cardsInGame";
-import { ApplicationState } from "$lib/constants/applicationState";
+import { type GameState } from '$lib/interfaces/gameState';
+import { type Player } from '$lib/interfaces/player';
+import { type GameEvent } from '$lib/interfaces/gameEvent';
+import { cardsInGame } from '$lib/constants/cardsInGame';
+import { ApplicationState } from '$lib/constants/applicationState';
 
 export namespace game {
 	// Modify state for starting the game.
@@ -15,34 +15,23 @@ export namespace game {
 	}
 
 	// Modify state for adding a new player.
-	export function addPlayer(
-		gameState: GameState,
-		playerName: string,
-	): GameState {
+	export function addPlayer(gameState: GameState, playerName: string): GameState {
 		const newPlayer: Player = {
 			id: gameState.players.length + 1,
-			name: playerName,
+			name: playerName
 		};
 		gameState.players = [...gameState.players, newPlayer];
 		return gameState;
 	}
 
 	// Modify state for removing a player.
-	export function removePlayer(
-		gameState: GameState,
-		playerId: number,
-	): GameState {
-		gameState.players = gameState.players.filter((player) =>
-			player.id !== playerId
-		);
+	export function removePlayer(gameState: GameState, playerId: number): GameState {
+		gameState.players = gameState.players.filter((player) => player.id !== playerId);
 		return gameState;
 	}
 
 	// Modify "state" of GameState.
-	export function changeGameState(
-		gameState: GameState,
-		newState: ApplicationState,
-	): GameState {
+	export function changeGameState(gameState: GameState, newState: ApplicationState): GameState {
 		gameState.state = newState;
 		return gameState;
 	}
@@ -59,7 +48,7 @@ export namespace game {
 			gameState.events.forEach((event) => {
 				event.ended = true;
 			});
-			return changeGameState(gameState, ApplicationState.GAME_OVER);
+			return changeGameState(gameState, ApplicationState.ENDING);
 		}
 		if (gameState.currentPlayerIndex >= gameState.players.length) {
 			gameState.currentPlayerIndex = 0;
@@ -79,7 +68,7 @@ export namespace game {
 				title: gameState.cards[gameState.currentCardIndex].title,
 				person: gameState.players[gameState.currentPlayerIndex].name,
 				startingIndex: gameState.currentPlayerIndex,
-				ended: false,
+				ended: false
 			};
 			gameState.events.push(event);
 		}
@@ -93,7 +82,7 @@ export namespace game {
 		const card = gameState.cards[cardIndex];
 
 		if (!card.targetPlayer) {
-			return "";
+			return '';
 		}
 
 		let randomIndex = playerIndex;

--- a/src/lib/managers/game.ts
+++ b/src/lib/managers/game.ts
@@ -1,8 +1,8 @@
-import { type GameState } from '$lib/interfaces/gameState';
-import { type Player } from '$lib/interfaces/player';
-import { type GameEvent } from '$lib/interfaces/gameEvent';
-import { cardsInGame } from '$lib/constants/cardsInGame';
-import { ApplicationState } from '$lib/constants/applicationState';
+import { type GameState } from "$lib/interfaces/gameState";
+import { type Player } from "$lib/interfaces/player";
+import { type GameEvent } from "$lib/interfaces/gameEvent";
+import { cardsInGame } from "$lib/constants/cardsInGame";
+import { ApplicationState } from "$lib/constants/applicationState";
 
 export namespace game {
 	// Modify state for starting the game.
@@ -15,20 +15,34 @@ export namespace game {
 	}
 
 	// Modify state for adding a new player.
-	export function addPlayer(gameState: GameState, playerName: string): GameState {
-		const newPlayer: Player = { id: gameState.players.length + 1, name: playerName };
+	export function addPlayer(
+		gameState: GameState,
+		playerName: string,
+	): GameState {
+		const newPlayer: Player = {
+			id: gameState.players.length + 1,
+			name: playerName,
+		};
 		gameState.players = [...gameState.players, newPlayer];
 		return gameState;
 	}
 
 	// Modify state for removing a player.
-	export function removePlayer(gameState: GameState, playerId: number): GameState {
-		gameState.players = gameState.players.filter((player) => player.id !== playerId);
+	export function removePlayer(
+		gameState: GameState,
+		playerId: number,
+	): GameState {
+		gameState.players = gameState.players.filter((player) =>
+			player.id !== playerId
+		);
 		return gameState;
 	}
 
 	// Modify "state" of GameState.
-	export function changeGameState(gameState: GameState, newState: ApplicationState): GameState {
+	export function changeGameState(
+		gameState: GameState,
+		newState: ApplicationState,
+	): GameState {
 		gameState.state = newState;
 		return gameState;
 	}
@@ -65,7 +79,7 @@ export namespace game {
 				title: gameState.cards[gameState.currentCardIndex].title,
 				person: gameState.players[gameState.currentPlayerIndex].name,
 				startingIndex: gameState.currentPlayerIndex,
-				ended: false
+				ended: false,
 			};
 			gameState.events.push(event);
 		}
@@ -79,7 +93,7 @@ export namespace game {
 		const card = gameState.cards[cardIndex];
 
 		if (!card.targetPlayer) {
-			return '';
+			return "";
 		}
 
 		let randomIndex = playerIndex;

--- a/src/lib/stores/gameStore.ts
+++ b/src/lib/stores/gameStore.ts
@@ -1,81 +1,81 @@
 // src/lib/stores/gameStore.ts
-import { get, writable } from "svelte/store";
-import type { GameState } from "../interfaces/gameState";
-import { createNewGame } from "../interfaces/gameState";
-import { game } from "../managers/game";
-import { ApplicationState } from "../constants/applicationState";
-import { loadGameState, saveGameState } from "../utils/storage";
-import { languageStore } from "./languageStore";
+import { get, writable } from 'svelte/store';
+import type { GameState } from '../interfaces/gameState';
+import { createNewGame } from '../interfaces/gameState';
+import { game } from '../managers/game';
+import { ApplicationState } from '../constants/applicationState';
+import { loadGameState, saveGameState } from '../utils/storage';
+import { languageStore } from './languageStore';
 
 function createGameStore() {
-  const { subscribe, set, update } = writable<GameState>(createNewGame());
+	const { subscribe, set, update } = writable<GameState>(createNewGame());
 
-  return {
-    subscribe,
-    set: (state: GameState) => {
-      saveGameState(state);
-      set(state);
-    },
-    reset: () => {
-      const newState = createNewGame();
-      sessionStorage.removeItem("gameState");
-      set(newState);
-    },
-    changeGameState: (newState: ApplicationState) => {
-      update((state) => {
-        const updatedState = game.changeGameState(state, newState);
-        saveGameState(updatedState);
-        return updatedState;
-      });
-    },
-    addPlayer: (playerName: string) => {
-      update((state) => {
-        const updatedState = game.addPlayer(state, playerName);
-        saveGameState(updatedState);
-        return updatedState;
-      });
-    },
-    removePlayer: (playerId: number) => {
-      update((state) => {
-        const updatedState = game.removePlayer(state, playerId);
-        saveGameState(updatedState);
-        return updatedState;
-      });
-    },
-    startGame: async () => {
-      const cards = await languageStore.getCards();
-      if (cards) {
-        update((state) => {
-          state.cards = cards;
-          const updatedState = game.startGame(state);
-          saveGameState(updatedState);
-          return updatedState;
-        });
-      }
-    },
-    showNextCard: () => {
-      update((state) => {
-        const updatedState = game.showNextCard(state);
-        saveGameState(updatedState);
-        return updatedState;
-      });
-    },
-    updateCards: async () => {
-      const cards = await languageStore.getCards();
-      if (cards) {
-        update((state) => ({
-          ...state,
-          cards: cards,
-        }));
-      }
-    },
-    loadSavedState: () => {
-      const savedState = loadGameState();
-      if (savedState) {
-        set(savedState);
-      }
-    },
-  };
+	return {
+		subscribe,
+		set: (state: GameState) => {
+			saveGameState(state);
+			set(state);
+		},
+		reset: () => {
+			const newState = createNewGame();
+			sessionStorage.removeItem('gameState');
+			set(newState);
+		},
+		changeGameState: (newState: ApplicationState) => {
+			update((state) => {
+				const updatedState = game.changeGameState(state, newState);
+				saveGameState(updatedState);
+				return updatedState;
+			});
+		},
+		addPlayer: (playerName: string) => {
+			update((state) => {
+				const updatedState = game.addPlayer(state, playerName);
+				saveGameState(updatedState);
+				return updatedState;
+			});
+		},
+		removePlayer: (playerId: number) => {
+			update((state) => {
+				const updatedState = game.removePlayer(state, playerId);
+				saveGameState(updatedState);
+				return updatedState;
+			});
+		},
+		startGame: async () => {
+			const cards = await languageStore.getCards();
+			if (cards) {
+				update((state) => {
+					state.cards = cards;
+					const updatedState = game.startGame(state);
+					saveGameState(updatedState);
+					return updatedState;
+				});
+			}
+		},
+		showNextCard: () => {
+			update((state) => {
+				const updatedState = game.showNextCard(state);
+				saveGameState(updatedState);
+				return updatedState;
+			});
+		},
+		updateCards: async () => {
+			const cards = await languageStore.getCards();
+			if (cards) {
+				update((state) => ({
+					...state,
+					cards: cards
+				}));
+			}
+		},
+		loadSavedState: () => {
+			const savedState = loadGameState();
+			if (savedState) {
+				set(savedState);
+			}
+		}
+	};
 }
 
 export const gameStore = createGameStore();

--- a/src/lib/stores/gameStore.ts
+++ b/src/lib/stores/gameStore.ts
@@ -1,0 +1,81 @@
+// src/lib/stores/gameStore.ts
+import { get, writable } from "svelte/store";
+import type { GameState } from "../interfaces/gameState";
+import { createNewGame } from "../interfaces/gameState";
+import { game } from "../managers/game";
+import { ApplicationState } from "../constants/applicationState";
+import { loadGameState, saveGameState } from "../utils/storage";
+import { languageStore } from "./languageStore";
+
+function createGameStore() {
+  const { subscribe, set, update } = writable<GameState>(createNewGame());
+
+  return {
+    subscribe,
+    set: (state: GameState) => {
+      saveGameState(state);
+      set(state);
+    },
+    reset: () => {
+      const newState = createNewGame();
+      sessionStorage.removeItem("gameState");
+      set(newState);
+    },
+    changeGameState: (newState: ApplicationState) => {
+      update((state) => {
+        const updatedState = game.changeGameState(state, newState);
+        saveGameState(updatedState);
+        return updatedState;
+      });
+    },
+    addPlayer: (playerName: string) => {
+      update((state) => {
+        const updatedState = game.addPlayer(state, playerName);
+        saveGameState(updatedState);
+        return updatedState;
+      });
+    },
+    removePlayer: (playerId: number) => {
+      update((state) => {
+        const updatedState = game.removePlayer(state, playerId);
+        saveGameState(updatedState);
+        return updatedState;
+      });
+    },
+    startGame: async () => {
+      const cards = await languageStore.getCards();
+      if (cards) {
+        update((state) => {
+          state.cards = cards;
+          const updatedState = game.startGame(state);
+          saveGameState(updatedState);
+          return updatedState;
+        });
+      }
+    },
+    showNextCard: () => {
+      update((state) => {
+        const updatedState = game.showNextCard(state);
+        saveGameState(updatedState);
+        return updatedState;
+      });
+    },
+    updateCards: async () => {
+      const cards = await languageStore.getCards();
+      if (cards) {
+        update((state) => ({
+          ...state,
+          cards: cards,
+        }));
+      }
+    },
+    loadSavedState: () => {
+      const savedState = loadGameState();
+      if (savedState) {
+        set(savedState);
+      }
+    },
+  };
+}
+
+export const gameStore = createGameStore();

--- a/src/lib/stores/gameStore.ts
+++ b/src/lib/stores/gameStore.ts
@@ -5,6 +5,7 @@ import { game } from '../managers/game';
 import { ApplicationState } from '../constants/applicationState';
 import { loadGameState, saveGameState } from '../utils/storage';
 import { languageStore } from './languageStore';
+import { loadCards } from '$lib/languages/load';
 
 function createGameStore() {
 	const { subscribe, set, update } = writable<GameState>(createNewGame());
@@ -42,6 +43,7 @@ function createGameStore() {
 			});
 		},
 		startGame: async () => {
+			await loadCards(fetch);
 			const cards = await languageStore.getCards();
 			if (cards) {
 				update((state) => {

--- a/src/lib/stores/gameStore.ts
+++ b/src/lib/stores/gameStore.ts
@@ -1,10 +1,10 @@
 import { writable } from 'svelte/store';
-import type { GameState } from '../interfaces/gameState';
-import { createNewGame } from '../interfaces/gameState';
-import { game } from '../managers/game';
-import { ApplicationState } from '../constants/applicationState';
-import { loadGameState, saveGameState } from '../utils/storage';
-import { languageStore } from './languageStore';
+import type { GameState } from '$lib/interfaces/gameState';
+import { createNewGame } from '$lib/interfaces/gameState';
+import { game } from '$lib/managers/game';
+import { ApplicationState } from '$lib/constants/applicationState';
+import { loadGameState, saveGameState } from '$lib/utils/storage';
+import { languageStore } from '$lib/stores/languageStore';
 import { loadCards } from '$lib/languages/load';
 
 function createGameStore() {

--- a/src/lib/stores/gameStore.ts
+++ b/src/lib/stores/gameStore.ts
@@ -1,5 +1,4 @@
-// src/lib/stores/gameStore.ts
-import { get, writable } from 'svelte/store';
+import { writable } from 'svelte/store';
 import type { GameState } from '../interfaces/gameState';
 import { createNewGame } from '../interfaces/gameState';
 import { game } from '../managers/game';

--- a/src/lib/stores/languageStore.ts
+++ b/src/lib/stores/languageStore.ts
@@ -1,7 +1,7 @@
 import { get, writable } from 'svelte/store';
-import { Language } from '../languages/language';
-import { setLanguage } from '../languages/load';
-import { getCardData } from '../languages/translation';
+import { Language } from '$lib/languages/language';
+import { setLanguage } from '$lib/languages/load';
+import { getCardData } from '$lib/languages/translation';
 
 function createLanguageStore() {
 	const { subscribe, set, update } = writable(Language.FI);

--- a/src/lib/stores/languageStore.ts
+++ b/src/lib/stores/languageStore.ts
@@ -1,0 +1,27 @@
+// src/lib/stores/languageStore.ts
+import { get, writable } from "svelte/store";
+import { Language } from "../languages/language";
+import { setLanguage } from "../languages/load";
+import { getCardData } from "../languages/translation";
+
+function createLanguageStore() {
+	const { subscribe, set, update } = writable(Language.FI);
+	const store = { subscribe, set, update };
+
+	return {
+		subscribe,
+		async changeLanguage(newLanguage: Language) {
+			const currentLanguage = get(store);
+			if (newLanguage !== currentLanguage) {
+				await setLanguage(newLanguage);
+				set(newLanguage);
+			}
+		},
+		async getCards() {
+			const currentLanguage = get(store);
+			return await getCardData(currentLanguage);
+		},
+	};
+}
+
+export const languageStore = createLanguageStore();

--- a/src/lib/stores/languageStore.ts
+++ b/src/lib/stores/languageStore.ts
@@ -1,8 +1,8 @@
 // src/lib/stores/languageStore.ts
-import { get, writable } from "svelte/store";
-import { Language } from "../languages/language";
-import { setLanguage } from "../languages/load";
-import { getCardData } from "../languages/translation";
+import { get, writable } from 'svelte/store';
+import { Language } from '../languages/language';
+import { setLanguage } from '../languages/load';
+import { getCardData } from '../languages/translation';
 
 function createLanguageStore() {
 	const { subscribe, set, update } = writable(Language.FI);
@@ -20,7 +20,7 @@ function createLanguageStore() {
 		async getCards() {
 			const currentLanguage = get(store);
 			return await getCardData(currentLanguage);
-		},
+		}
 	};
 }
 

--- a/src/lib/stores/languageStore.ts
+++ b/src/lib/stores/languageStore.ts
@@ -1,4 +1,3 @@
-// src/lib/stores/languageStore.ts
 import { get, writable } from 'svelte/store';
 import { Language } from '../languages/language';
 import { setLanguage } from '../languages/load';

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script>
 	import '@picocss/pico';
-	import '@picocss/pico/css/pico.colors.css'
+	import '@picocss/pico/css/pico.colors.css';
 </script>
 
 <slot />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script>
 	import '@picocss/pico';
+	import '@picocss/pico/css/pico.colors.css'
 </script>
 
 <slot />

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,10 +1,9 @@
 import type { LoadEvent } from '@sveltejs/kit';
 import { waitLocale } from 'svelte-i18n';
-import { loadCards, registerLocales } from '$lib/languages/load';
+import { registerLocales } from '$lib/languages/load';
 
 export async function load({ fetch }: LoadEvent) {
 	registerLocales(fetch);
-	await loadCards(fetch);
 	await waitLocale();
 	return {};
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,7 @@
 	import { gameStore } from '$lib/stores/gameStore';
 
 	import Header from '$lib/components/Header.svelte';
-	import Landing from '$lib/components/Landing.svelte';
+	import Start from '$lib/components/Start.svelte';
 	import Lobby from '$lib/components/Lobby.svelte';
 	import Game from '$lib/components/Game.svelte';
 
@@ -18,24 +18,22 @@
 	onMount(() => {
 		gameStore.loadSavedState();
 	});
-
 </script>
 
 <div class="game-container">
-	<Header/>
-	{#if gameState.state === ApplicationState.LOBBY}
-		<Landing />
-	{:else if gameState.state === ApplicationState.ADDING_PLAYERS}
+	<Header />
+	{#if gameState.state === ApplicationState.START}
+		<Start />
+	{:else if gameState.state === ApplicationState.LOBBY}
 		<Lobby />
 	{:else if gameState.state === ApplicationState.PLAYING}
 		<Game />
-	{:else if gameState.state === ApplicationState.GAME_OVER}
+	{:else if gameState.state === ApplicationState.ENDING}
 		<h1>{$t('game-over')}</h1>
 		<button
 			on:click={() => {
-				gameStore.changeGameState(ApplicationState.LOBBY);
-				gameState.events = [];
-				gameStore.set(gameState);
+				gameStore.changeGameState(ApplicationState.START);
+				gameStore.reset();
 			}}
 		>
 			{$t('back-to-start')}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,12 +30,7 @@
 		<Game />
 	{:else if gameState.state === ApplicationState.ENDING}
 		<h1>{$t('game-over')}</h1>
-		<button
-			on:click={() => {
-				gameStore.changeGameState(ApplicationState.START);
-				gameStore.reset();
-			}}
-		>
+		<button on:click={gameStore.reset}>
 			{$t('back-to-start')}
 		</button>
 	{/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,164 +1,45 @@
 <script lang="ts">
-	import { game } from '$lib/managers/game';
-	import { cardsInGame } from '$lib/constants/cardsInGame';
-	import { Language } from '$lib/languages/language';
-	import { loadCards, setLanguage } from '$lib/languages/load';
-	import { ApplicationState } from '$lib/constants/applicationState';
-	import { createNewGame } from '$lib/interfaces/gameState';
-	import { loadGameState, saveGameState } from '$lib/utils/storage';
-
 	import { onMount } from 'svelte';
 	import { t } from 'svelte-i18n';
-	import { getCardData } from '$lib/languages/translation';
+
+	import { ApplicationState } from '$lib/constants/applicationState';
+	import type { GameState } from '$lib/interfaces/gameState';
+	import { gameStore } from '$lib/stores/gameStore';
+
+	import Header from '$lib/components/Header.svelte';
+	import Landing from '$lib/components/Landing.svelte';
+	import Lobby from '$lib/components/Lobby.svelte';
+	import Game from '$lib/components/Game.svelte';
 
 	// State of the application.
-	let gameState = createNewGame();
-
-	// The language the application is using.
-	let currentLanguage = Language.FI;
+	let gameState: GameState;
+	gameStore.subscribe((value) => (gameState = value));
 
 	onMount(() => {
-		const newGameState = loadGameState();
-		if (newGameState) {
-			gameState = newGameState;
-		}
+		gameStore.loadSavedState();
 	});
 
-	async function resetGame() {
-		await loadCards(fetch);
-		gameState = createNewGame();
-		sessionStorage.removeItem('gameState');
-	}
-
-	function changeGameState(newState: ApplicationState) {
-		gameState = game.changeGameState(gameState, newState);
-		saveGameState(gameState);
-	}
-
-	async function startGame() {
-		await getCards();
-		gameState = game.startGame(gameState);
-		saveGameState(gameState);
-	}
-
-	function addPlayer(playerName: string) {
-		gameState = game.addPlayer(gameState, playerName);
-		saveGameState(gameState);
-	}
-
-	function removePlayer(playerId: number) {
-		gameState = game.removePlayer(gameState, playerId);
-		saveGameState(gameState);
-	}
-
-	function handleKeyPress(event: KeyboardEvent) {
-		if (event.key === 'Enter') {
-			addPlayer(gameState.playerName);
-			gameState.playerName = '';
-		}
-	}
-
-	function showNextCard() {
-		gameState = game.showNextCard(gameState);
-		saveGameState(gameState);
-	}
-
-	async function getCards() {
-		let cards = await getCardData(currentLanguage);
-		if (cards) {
-			gameState.cards = cards;
-		}
-	}
-
-	async function changeLanguage(event: Event) {
-		const select = event.target as HTMLSelectElement;
-		const newLanguage = select.value as Language;
-
-		if (newLanguage !== currentLanguage) {
-			await setLanguage(newLanguage);
-			currentLanguage = newLanguage;
-			await getCards();
-		} else {
-			console.warn('Language is already set to: ', currentLanguage);
-		}
-	}
 </script>
 
 <div class="game-container">
-	<select class="language-selector" on:change={changeLanguage} title="Change Language">
-		{#each Object.values(Language) as language}
-			<option value={language}>{language}</option>
-		{/each}
-	</select>
-
-	<button class="reset-button" on:click={resetGame} title="Reset Game">
-		&#x21bb; <!-- Unicode for a circular reset icon -->
-	</button>
-
+	<Header/>
 	{#if gameState.state === ApplicationState.LOBBY}
-		<h1>{$t('title')}</h1>
-		<button class="button" on:click={() => changeGameState(ApplicationState.ADDING_PLAYERS)}
-			>{$t('main-menu-start-button')}</button
-		>
+		<Landing />
 	{:else if gameState.state === ApplicationState.ADDING_PLAYERS}
-		<h2>{$t('add-player-names')}</h2>
-		<input
-			type="text"
-			bind:value={gameState.playerName}
-			placeholder={$t('add-player-name')}
-			on:keypress={handleKeyPress}
-			class="input"
-		/>
-		{#if gameState.players.length > 0}
-			<ul class="player-list">
-				{#each gameState.players as player (player.id)}
-					<li>
-						<button class="remove-player" on:click={() => removePlayer(player.id)}>&#x2716;</button>
-						{player.name}
-					</li>
-				{/each}
-			</ul>
-		{/if}
-		<button class="button button-green" disabled={gameState.players.length < 2} on:click={startGame}
-			>{$t('game-start-button')}</button
-		>
+		<Lobby />
 	{:else if gameState.state === ApplicationState.PLAYING}
-		<h1 class="target">
-			{gameState.players[gameState.currentPlayerIndex].name}
-		</h1>
-
-		<article>
-			<h2>{gameState.cards[gameState.currentCardIndex].title}</h2>
-			<p>
-				{gameState.cards[gameState.currentCardIndex].description}
-			</p>
-			{#if gameState.cards[gameState.currentCardIndex].targetPlayer}
-				<b>{$t('target')}: {game.getTarget(gameState)}</b>
-			{/if}
-		</article>
-
-		{#each gameState.events as event}
-			{#if event.ended === true}
-				<h1 class="event-text">{event.person}, {$t('can-stop-the-mission')} {event.title}</h1>
-			{/if}
-		{/each}
-		{#if gameState.currentCardIndex + 1 < 29}
-			<button class="button" on:click={showNextCard}>{$t('next-card')}</button>
-		{:else if gameState.currentCardIndex + 1 === 29}
-			<button class="button" on:click={showNextCard}>{$t('last-card')}</button>
-		{:else if gameState.currentCardIndex + 1 === 30}
-			<button class="button button-red" on:click={showNextCard}>{$t('game-over')}</button>
-		{/if}
-		<p class="game-status">{gameState.currentCardIndex + 1}/{cardsInGame}</p>
+		<Game />
 	{:else if gameState.state === ApplicationState.GAME_OVER}
 		<h1>{$t('game-over')}</h1>
 		<button
-			class="button"
 			on:click={() => {
-				changeGameState(ApplicationState.LOBBY);
+				gameStore.changeGameState(ApplicationState.LOBBY);
 				gameState.events = [];
-			}}>{$t('back-to-start')}</button
+				gameStore.set(gameState);
+			}}
 		>
+			{$t('back-to-start')}
+		</button>
 	{/if}
 </div>
 
@@ -170,79 +51,5 @@
 		justify-content: center;
 		width: 100%;
 		height: 100vh;
-	}
-
-	.button-green {
-		background-color: #2ecc71;
-	}
-
-	.player-list {
-		padding-left: 0;
-	}
-
-	.player-list li {
-		list-style-type: none;
-	}
-
-	.remove-player {
-		all: unset;
-		background-color: transparent;
-		cursor: pointer;
-		font-size: 14px;
-		color: #666;
-		transition: color 0.2s ease;
-	}
-
-	.remove-player:hover {
-		color: #e74c3c;
-	}
-
-	input {
-		width: 50%;
-		max-width: 300px;
-		padding: 0.5rem 1rem;
-		border-radius: 0.5rem;
-		outline: none;
-	}
-
-	input:focus {
-		border-color: #2980b9;
-	}
-
-	article {
-		width: 50%;
-		max-width: 600px;
-	}
-
-	.game-status {
-		margin-top: 1rem;
-	}
-
-	.reset-button,
-	.language-selector {
-		position: absolute;
-		top: 1rem;
-		width: 2.5rem;
-		height: 2.5rem;
-		padding: 0;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		text-align: center;
-		border-radius: 50%;
-		font-size: 1.2rem;
-		line-height: 1;
-	}
-
-	.reset-button {
-		right: 1rem;
-	}
-
-	.language-selector {
-		left: 1rem;
-		appearance: none;
-		background-image: none !important;
-		-webkit-appearance: none;
-		-moz-appearance: none;
 	}
 </style>


### PR DESCRIPTION
This one is big.

This PR refactors all the code in `+page.svelte` into separate Svelte components. The refactor also introduces two new Svelte stores:
- `gameStore.ts` for game state-specific functionality
- `languageStore.ts` for setting a language and fetching the cards

Additionally, it includes miscellaneous styling changes, state renaming, and more. Functionality should be on par with the current master branch.

This requires additional testing and thorough code review.

State changes:
```
"LOBBY" → "START"
"ADDING_PLAYERS" → "LOBBY"
"PLAYING" → "PLAYING"
"GAME_OVER" → "ENDING"
```