### PR TITLE
feat: Implement game settings with configurable card count

### DIFF
--- a/src/lib/components/Game.svelte
+++ b/src/lib/components/Game.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { t } from 'svelte-i18n';
-	import { cardsInGame } from '$lib/constants/cardsInGame';
 	import { game } from '$lib/managers/game';
 	import type { GameState } from '$lib/interfaces/gameState';
 	import { gameStore } from '$lib/stores/gameStore';
@@ -29,17 +28,15 @@
 	{/if}
 {/each}
 
-{#if gameState.currentCardIndex + 1 < 29}
+{#if gameState.currentCardIndex + 1 < gameState.cardAmount}
 	<button on:click={gameStore.showNextCard}>{$t('next-card')}</button>
-{:else if gameState.currentCardIndex + 1 === 29}
-	<button on:click={gameStore.showNextCard}>{$t('last-card')}</button>
-{:else if gameState.currentCardIndex + 1 === 30}
-	<button class="pico-background-red-500" on:click={gameStore.showNextCard}
-		>{$t('game-over')}</button
-	>
+{:else}
+	<button class="pico-background-red-500" on:click={gameStore.showNextCard}>
+		{$t('game-over')}
+	</button>
 {/if}
 
-<p class="game-status">{gameState.currentCardIndex + 1}/{cardsInGame}</p>
+<p class="game-status">{gameState.currentCardIndex + 1}/{gameState.cardAmount}</p>
 
 <style>
 	article {

--- a/src/lib/components/Lobby.svelte
+++ b/src/lib/components/Lobby.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { t } from 'svelte-i18n';
 	import { gameStore } from '$lib/stores/gameStore';
 	import type { GameState } from '$lib/interfaces/gameState';
@@ -6,12 +7,9 @@
 	let gameState: GameState;
 	gameStore.subscribe((value) => (gameState = value));
 
-	function handleKeyPress(event: KeyboardEvent) {
-		if (event.key === 'Enter' && gameState.playerName) {
-			gameStore.addPlayer(gameState.playerName);
-			gameState.playerName = '';
-		}
-	}
+	onMount(() => {
+		gameStore.initializeMaxCards();
+	});
 </script>
 
 <h2>{$t('add-player-names')}</h2>
@@ -19,7 +17,12 @@
 	type="text"
 	bind:value={gameState.playerName}
 	placeholder={$t('add-player-name')}
-	on:keypress={handleKeyPress}
+	on:keydown={(e) => {
+		if (e.key === 'Enter' && gameState.playerName) {
+			gameStore.addPlayer(gameState.playerName);
+			gameState.playerName = '';
+		}
+	}}
 	class="input"
 />
 {#if gameState.players.length > 0}
@@ -34,6 +37,25 @@
 		{/each}
 	</ul>
 {/if}
+<details>
+	<summary>
+		<span>{$t('settings')}</span>
+	</summary>
+	<div class="settings">
+		<span>{$t('settings-cards')}:</span>
+		<div class="slider-container">
+			<span>{gameState.cardAmount}</span>
+			<input
+				type="range"
+				id="cardAmount"
+				name="cardAmount"
+				min="10"
+				max={gameState.maxCards ?? 10}
+				bind:value={gameState.cardAmount}
+			/>
+		</div>
+	</div>
+</details>
 <button
 	class="pico-background-jade-500"
 	disabled={gameState.players.length < 2}
@@ -74,5 +96,27 @@
 
 	input:focus {
 		border-color: #2980b9;
+	}
+
+	summary {
+		font-size: 0.9rem;
+		color: #666;
+	}
+
+	.settings {
+		font-size: 0.9rem;
+	}
+
+	.slider-container {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		flex: 1;
+	}
+
+	input[type='range'] {
+		padding: 0;
+		margin: 0;
+		flex: 1;
 	}
 </style>

--- a/src/lib/constants/cardsInGame.ts
+++ b/src/lib/constants/cardsInGame.ts
@@ -1,1 +1,0 @@
-export const cardsInGame = 30;

--- a/src/lib/interfaces/gameState.ts
+++ b/src/lib/interfaces/gameState.ts
@@ -5,6 +5,8 @@ import { type Player } from '$lib/interfaces/player';
 
 export interface GameState {
 	cards: Card[];
+	cardAmount: number;
+	maxCards: number | undefined;
 	playerName: string;
 	currentCardIndex: number;
 	currentPlayerIndex: number;
@@ -16,6 +18,8 @@ export interface GameState {
 export function createNewGame(): GameState {
 	return {
 		cards: [],
+		cardAmount: 30, // default value
+		maxCards: undefined,
 		playerName: '',
 		currentCardIndex: 0,
 		currentPlayerIndex: 0,

--- a/src/lib/managers/game.ts
+++ b/src/lib/managers/game.ts
@@ -1,7 +1,6 @@
 import { type GameState } from '$lib/interfaces/gameState';
 import { type Player } from '$lib/interfaces/player';
 import { type GameEvent } from '$lib/interfaces/gameEvent';
-import { cardsInGame } from '$lib/constants/cardsInGame';
 import { ApplicationState } from '$lib/constants/applicationState';
 
 export namespace game {
@@ -43,7 +42,7 @@ export namespace game {
 
 		// Go to game over if out of cards.
 		// Card index doesn't have to be updated since it's always updated in startGame().
-		if (gameState.currentCardIndex >= cardsInGame) {
+		if (gameState.currentCardIndex >= gameState.cardAmount) {
 			// All ongoing events automatically end.
 			gameState.events.forEach((event) => {
 				event.ended = true;

--- a/src/lib/stores/gameStore.ts
+++ b/src/lib/stores/gameStore.ts
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import type { GameState } from '$lib/interfaces/gameState';
 import { createNewGame } from '$lib/interfaces/gameState';
 import { game } from '$lib/managers/game';
@@ -42,12 +42,29 @@ function createGameStore() {
 				return updatedState;
 			});
 		},
+		setCardAmount: (amount: number) => {
+			update((state) => {
+				const updatedState = { ...state, cardAmount: amount };
+				saveGameState(updatedState);
+				return updatedState;
+			});
+		},
+		initializeMaxCards: async () => {
+			const maxCards = await loadCards(fetch, get(gameStore).cardAmount);
+			if (maxCards) {
+				update((state) => ({
+					...state,
+					maxCards
+				}));
+			}
+		},
 		startGame: async () => {
-			await loadCards(fetch);
+			const maxCards = await loadCards(fetch, get(gameStore).cardAmount);
 			const cards = await languageStore.getCards();
 			if (cards) {
 				update((state) => {
 					state.cards = cards;
+					state.maxCards = maxCards;
 					const updatedState = game.startGame(state);
 					saveGameState(updatedState);
 					return updatedState;

--- a/static/locales/english.json
+++ b/static/locales/english.json
@@ -2,12 +2,13 @@
     "title": "Santeri's Drinking Game v2",
     "main-menu-start-button": "Start",
     "add-player-names": "Add player names",
-    "game-start-button": "Let's get drinking",
     "add-player-name": "Insert player name",
+    "settings": "Settings",
+    "settings-cards": "Cards",
+    "game-start-button": "Let's get drinking",
     "can-stop-the-mission": "you can stop the task",
     "target": "Target",
     "next-card": "Next card",
-    "last-card": "Last card",
     "game-over": "Game over",
     "back-to-start": "Back to start"
 }

--- a/static/locales/finnish.json
+++ b/static/locales/finnish.json
@@ -3,11 +3,12 @@
     "main-menu-start-button": "Aloita",
     "add-player-names": "Lisää pelaajien nimet",
     "add-player-name": "Lisää pelaajan nimi",
+    "settings": "Asetukset",
+    "settings-cards": "Kortit",
     "game-start-button": "Aloita ryyppääminen",
     "can-stop-the-mission": "voit lopettaa tehtävän",
     "target": "Kohde",
     "next-card": "Seuraava kortti",
-    "last-card": "Viimeinen kortti",
     "game-over": "Peli ohi",
     "back-to-start": "Takaisin alkuun"
 }


### PR DESCRIPTION
Added a settings accordion with the ability to configure the number of cards used in the game.

### Changes:
- `loadCards()` now returns `Promise<number>` to get maximum available cards
- Added `initializeMaxCards()` function to set maximum available cards on mount
- Removed handleKeyPress function in favor of Svelte's native on:keydown event
- Removed last-card string (i think its pointless)

🚀 